### PR TITLE
Wait for populated topicMap before connecting to broker

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,15 +68,16 @@ func main() {
 
 	brokers := []string{config.broker + ":9092"}
 	for {
-
-		client, err = sarama.NewClient(brokers, nil)
-		if client != nil && err == nil {
-			break
+		if len(topicMap.Topics()) > 0 {
+			client, err = sarama.NewClient(brokers, nil)
+			if client != nil && err == nil {
+				break
+			}
+			if client != nil {
+				client.Close()
+			}
+			fmt.Println("Wait for brokers ("+config.broker+") to come up.. ", brokers)
 		}
-		if client != nil {
-			client.Close()
-		}
-		fmt.Println("Wait for brokers ("+config.broker+") to come up.. ", brokers)
 
 		time.Sleep(1 * time.Second)
 	}

--- a/types/topic_map.go
+++ b/types/topic_map.go
@@ -40,3 +40,15 @@ func (t *TopicMap) Sync(updated *map[string][]string) {
 
 	t.lookup = updated
 }
+
+func (t *TopicMap) Topics() []string {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	topics := make([]string, 0, len(*t.lookup))
+	for topic := range *t.lookup {
+		topics = append(topics, topic)
+	}
+
+	return topics
+}


### PR DESCRIPTION
Before this PR restarting/scaling to `0` and back again with the `kafka-connector` would result in any outstanding queued messages being immediately received by the connector on restart but before
the `topicMap` sync would have been completed.

This would result in function trigger events being handled before a target function could be determined, effectively blackhole-ing the function trigger.

This change delays the `kafka-connector` connection to the broker until a non-empty `topicMap` is returned, thereby guaranteeing any already configured functions will be triggered as expected.

It adds a `Topics()` method to the `topicMap` as a mechanism for determining that it has been synced, this approach is from the `nats-connector` implementation which I'm currently testing. NATS doesn't let you subscribe to multiple subjects (topics) in a single call, hence the need to return a list of subjects.

#### Reproducing the problem
1. Deploy the kafka stack and the `figlet` function.
2. Tail the `kafka_connector` service logs.
3. Trigger `figlet` via kafka and observe the function being handled in the tailed service logs.
4. Scale the `kafka_connector` to `0`, `docker service scale kafka_connector=0`
5. Observe the tailed service logs stopping the `Syncing topic map` heartbeat.
6. Trigger `figlet` via kafka again and observe no activity in the tailed service logs.
7. Scale the `kafka_connector` to `1`, `docker service scale kafka_connector=1`
8. Observe the tailed service logs resume the `Syncing topic map` heartbeat.
9. Observe the function trigger is received but no output is generated (the function is **not** triggered).
  ```[#1] Received on [faas-request,0]: 'BLACKHOLE'```

#### Verifying the fix
1. Build the updated `kafka_connector` image, and use it to replace the running version.
2. Follow steps `1` to `9` above, but this time when the `kafka_connector` is scaled back to 1 you will see the function output when the queued trigger is received - as we have waited for the `topicMap` to have become populated.
