### PR TITLE
Add multiple brokers and ports support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ This configuration can be set in the YAML files for Kubernetes or Swarm.
 | `rebuild_interval`      | Go duration - interval for rebuilding function to topic map |
 | `topics`                | Topics to which the connector will bind                     |
 | `gateway_url`           | The URL for the API gateway i.e. http://gateway:8080 or http://gateway.openfaas:8080 for Kubernetes       |
-| `broker_host`           | Default is `kafka`                                          |
+| `broker_hosts`          | Default host is `kafka:9092`, but you can add more or different hosts depending on your needs             |
 | `print_response`        | Default is `true` - this will output information about the response of calling a function in the logs, including the HTTP status, topic that triggered invocation, the function name, and the length of the response body in bytes |
 | `print_response_body`   | Default is `true` - this will print the body of the response of calling a function to stdout |
 | `topic_delimiter`   | Default is `,` - Specifies character upon which to split the `topic` annotation when subscribing a function to mulitple topics |

--- a/yaml/kubernetes/connector-dep.yml
+++ b/yaml/kubernetes/connector-dep.yml
@@ -1,4 +1,3 @@
-
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -35,11 +34,13 @@ spec:
             value: ","
           - name: asynchronous_invocation
             value: "true"
+          - name: broker_hosts
+            value: "kafka:9092,"
         volumeMounts:
             - name: auth
               readOnly: true
               mountPath: "/var/secrets/"
       volumes:
-      - name: auth
-        secret:
-          secretName: basic-auth
+        - name: auth
+          secret:
+            secretName: basic-auth


### PR DESCRIPTION
Adding support for multiple brokers and
different ports since until now the
port had to be 9092 and you could only have
one kafka broker

Closes #28 

Signed-off-by: mdekov <mdekov@vmware.com>