### PR TITLE
Add configuration for keepalive duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,4 +196,5 @@ This configuration can be set in the YAML files for Kubernetes or Swarm.
 | `broker_host`           | Default is `kafka`                                          |
 | `print_response`        | Default is `true` - this will output information about the response of calling a function in the logs, including the HTTP status, topic that triggered invocation, the function name, and the length of the response body in bytes |
 | `print_response_body`   | Default is `true` - this will print the body of the response of calling a function to stdout |
+| `keepalive_duration` | Default is `10s`, if you will consume lots of topics per second, in order to keep the round robin container invocation you should set this variable lower than the topics produced per second |
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_getKeepaliveConfig(t *testing.T) {
+	tests := []struct {
+		title                        string
+		environmentalKeepaliveConfig string
+		expectedConfig               time.Duration
+		expectedError                error
+	}{
+		{
+			title: "Keepalive set to 10 minutes",
+			environmentalKeepaliveConfig: "10m",
+			expectedConfig:               10 * time.Minute,
+			expectedError:                nil,
+		},
+		{
+			title: "Keepalive unset, falling back to default 10 seconds",
+			environmentalKeepaliveConfig: "",
+			expectedConfig:               10 * time.Second,
+			expectedError:                nil,
+		},
+		{
+			title: "Keepalive set but not in go duration",
+			environmentalKeepaliveConfig: "10",
+			expectedConfig:               0,
+			expectedError:                errors.New("time: missing unit in duration"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			os.Setenv("keepalive_duration", test.environmentalKeepaliveConfig)
+			keepaliveDuration, err := getKeepaliveConfig()
+			if test.expectedConfig != keepaliveDuration {
+				t.Errorf("expected keepalive duration to be: %v got: %v", test.expectedConfig, keepaliveDuration)
+			}
+			if err != nil {
+				if !strings.Contains(err.Error(), test.expectedError.Error()) {
+					t.Errorf("expected error from:`%s` type got: %s", test.expectedError.Error(), err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding new Transport for kafka which
resembles the original one provided by
the make_client.go from the SDK with
the key difference that here the keepalive
duration is configurable, also added unit
tests for the times when we would like to
configure the environmental variable and
add small documentation why the variable
is needed

Signed-off-by: Martin Dekov <mdekov@vmware.com>