### PR TITLE
Add one liner to view topic messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ $ kubectl exec -n openfaas -t -i $BROKER -- sh
 ./opt/kafka_2.12-0.11.0.1/bin/kafka-console-producer.sh
 ```
 
+With the `$BROKER` variable still set, view the list of messages on a given topic:
+
+```
+$ kubectl exec -n openfaas -t -i $BROKER -- /opt/kafka_2.12-0.11.0.1/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic faas-request --from-beginning
+```
+
 Now check the connector logs to see the figlet function was invoked:
 
 ```bash


### PR DESCRIPTION
A quick addition of a one-liner in README to help people wishing to verify messages are making it onto a given topic.

Signed-off-by: Richard Gee <richard@technologee.co.uk>