### PR TITLE
Add annotations via yaml example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Deploy a function with a `topic` annotation:
 $ faas store deploy figlet --annotation topic="faas-request" --gateway <faas-netes-gateway-url>
 ```
 
+If deploying via a `stack.yml` then add an annotation key called `topic` with a value of `faas-request`.
+
+```yaml
+  my-function:
+    lang: python
+    handler: ./my-function
+    image: <username>/my-function:latest
+    annotations:
+      topic: faas-request
+```
+
+For further details, please see the [YAML Reference](https://docs.openfaas.com/reference/yaml/#function-annotations) section of the [OpenFaaS Docs](https://docs.openfaas.com/)
+
 Deploy Kafka:
 
 You can run the zookeeper, kafka-broker and kafka-connector pods with:
@@ -208,4 +221,5 @@ This configuration can be set in the YAML files for Kubernetes or Swarm.
 | `broker_host`           | Default is `kafka`                                          |
 | `print_response`        | Default is `true` - this will output information about the response of calling a function in the logs, including the HTTP status, topic that triggered invocation, the function name, and the length of the response body in bytes |
 | `print_response_body`   | Default is `true` - this will print the body of the response of calling a function to stdout |
+| `topic_delimiter`   | Default is `,` - Specifies character upon which to split the `topic` annotation when subscribing a function to mulitple topics |
 


### PR DESCRIPTION
Fixes #34 

Adds a simple example to the README of how to add a topic annotation to a YML file.

Signed-off-by: Richard Gee <richard@technologee.co.uk>