### PR TITLE
Update YAML files for 1.16

### DIFF
--- a/yaml/kubernetes/connector-dep.yml
+++ b/yaml/kubernetes/connector-dep.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -8,6 +8,10 @@ metadata:
   namespace: openfaas
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+      component: kafka-connector
   template:
     metadata:
       labels:

--- a/yaml/kubernetes/kafka-broker-dep.yml
+++ b/yaml/kubernetes/kafka-broker-dep.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -8,6 +8,10 @@ metadata:
   namespace: openfaas
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+      component: kafka-broker
   template:
     metadata:
       labels:

--- a/yaml/kubernetes/zookeeper-dep.yaml
+++ b/yaml/kubernetes/zookeeper-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -8,6 +8,10 @@ metadata:
   namespace: openfaas
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+      component: zookeeper
   template:
     metadata:
       labels:


### PR DESCRIPTION
The Kubernetes v1.16 release has stopped serving the deprecated API
extensions/v1beta1 in favor of apps/v1.

Signed-off-by: Simon Castella <castella.simon@gmail.com>